### PR TITLE
Phase 8: Upgrade System & Version Tracking (v1.9.0)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,16 @@ generate-creds-k8s: ## Generate production credentials (K8s secrets YAML)
 	@./scripts/generate-credentials.sh --format=k8s-secrets
 
 # =============================================================================
+# Upgrade Commands
+# =============================================================================
+
+upgrade: ## Upgrade all services (pull images, migrate DB, restart)
+	./scripts/upgrade.sh
+
+upgrade-dry-run: ## Show what upgrade would do (no changes)
+	./scripts/upgrade.sh --dry-run
+
+# =============================================================================
 # Development Commands
 # =============================================================================
 

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Docker Compose upgrade script for ES1 Platform
+# Pulls new images, runs database migrations, restarts services with zero data loss.
+#
+# Usage:
+#   ./scripts/upgrade.sh              # Upgrade all services
+#   ./scripts/upgrade.sh --dry-run    # Show what would happen without making changes
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+    esac
+done
+
+# All compose files
+COMPOSE_FILES=(
+    "-f" "docker-compose.yml"
+    "-f" "docker-compose.airflow.yml"
+    "-f" "docker-compose.langfuse.yml"
+    "-f" "docker-compose.langflow.yml"
+    "-f" "docker-compose.aiml.yml"
+    "-f" "docker-compose.es1-platform-manager.yml"
+    "-f" "docker-compose.n8n.yml"
+    "-f" "docker-compose.agents.yml"
+    "-f" "docker-compose.crewai-studio.yml"
+    "-f" "docker-compose.autogen-studio.yml"
+    "-f" "docker-compose.monitoring.yml"
+)
+
+cd "$PROJECT_DIR"
+
+echo "=== ES1 Platform Upgrade ==="
+echo ""
+
+# Step 1: Pull latest images
+echo "Step 1: Pulling latest images..."
+if [ "$DRY_RUN" = true ]; then
+    echo "  [dry-run] Would pull all service images"
+else
+    docker compose "${COMPOSE_FILES[@]}" pull
+fi
+echo ""
+
+# Step 2: Run database migrations
+echo "Step 2: Running database migrations..."
+if [ "$DRY_RUN" = true ]; then
+    echo "  [dry-run] Would run: docker compose -f docker-compose.yml -f docker-compose.db-migrate.yml run --rm db-migrate"
+else
+    # Ensure databases are up before migrating
+    docker compose -f docker-compose.yml up -d postgres aiml-postgres
+    echo "  Waiting for databases to be ready..."
+    sleep 5
+
+    docker compose \
+        -f docker-compose.yml \
+        -f docker-compose.db-migrate.yml \
+        run --rm db-migrate || {
+            echo "WARNING: Migration failed. Services not restarted."
+            echo "Fix the migration issue and re-run this script."
+            exit 1
+        }
+fi
+echo ""
+
+# Step 3: Restart services with new images
+echo "Step 3: Restarting services with new images..."
+if [ "$DRY_RUN" = true ]; then
+    echo "  [dry-run] Would restart all services"
+else
+    docker compose "${COMPOSE_FILES[@]}" up -d
+fi
+echo ""
+
+# Step 4: Wait for health checks
+echo "Step 4: Waiting for services to become healthy..."
+if [ "$DRY_RUN" = true ]; then
+    echo "  [dry-run] Would wait for health checks"
+else
+    sleep 10
+    echo "  Checking service health..."
+
+    # Check Platform Manager API
+    if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
+        echo "  Platform Manager API: healthy"
+    else
+        echo "  Platform Manager API: not ready (may still be starting)"
+    fi
+
+    # Check KrakenD
+    if curl -sf http://localhost:8080/__health > /dev/null 2>&1; then
+        echo "  KrakenD: healthy"
+    else
+        echo "  KrakenD: not ready (may still be starting)"
+    fi
+fi
+echo ""
+
+echo "=== Upgrade complete ==="
+echo "Run 'docker compose ${COMPOSE_FILES[*]} ps' to check service status."

--- a/services/es1-platform-manager/api/app/core/config.py
+++ b/services/es1-platform-manager/api/app/core/config.py
@@ -15,6 +15,7 @@ class Settings(BaseSettings):
     # API
     API_V1_PREFIX: str = "/api/v1"
     PROJECT_NAME: str = "Platform Manager API"
+    PLATFORM_VERSION: str = "1.9.0"
 
     # CORS - restrict in production; wildcard only safe for local dev
     # Set to specific origins (e.g., ["http://localhost:3001"]) when AUTH_MODE != "none"

--- a/services/es1-platform-manager/api/app/main.py
+++ b/services/es1-platform-manager/api/app/main.py
@@ -69,7 +69,7 @@ async def lifespan(app: FastAPI):
     # Emit startup event
     await event_bus.publish(
         EventType.SYSTEM_INFO,
-        {"message": "Platform Manager started", "version": "1.0.0"},
+        {"message": "Platform Manager started", "version": settings.PLATFORM_VERSION},
     )
 
     yield
@@ -85,7 +85,7 @@ async def lifespan(app: FastAPI):
 # Create FastAPI app
 app = FastAPI(
     title=settings.PROJECT_NAME,
-    version="1.0.0",
+    version=settings.PLATFORM_VERSION,
     description="Platform Manager - Unified management for API Gateway, Workflows, and AI services",
     lifespan=lifespan,
 )

--- a/services/es1-platform-manager/api/app/modules/system/routes.py
+++ b/services/es1-platform-manager/api/app/modules/system/routes.py
@@ -1,4 +1,5 @@
 """System and scheduler routes."""
+import os
 from typing import Any
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
@@ -38,6 +39,33 @@ class SystemStatusResponse(BaseModel):
     integrations: dict[str, bool]
 
 
+class VersionResponse(BaseModel):
+    """Version information response."""
+    platform_version: str
+    api_version: str
+    runtime_mode: str
+    auth_mode: str
+    services: dict[str, bool]
+
+
+@router.get("/version", response_model=VersionResponse)
+async def get_version():
+    """Get platform version and service configuration."""
+    return VersionResponse(
+        platform_version=settings.PLATFORM_VERSION,
+        api_version=settings.API_V1_PREFIX,
+        runtime_mode=settings.RUNTIME_MODE,
+        auth_mode=settings.AUTH_MODE,
+        services={
+            "airflow": settings.AIRFLOW_ENABLED,
+            "langflow": settings.LANGFLOW_ENABLED,
+            "langfuse": settings.LANGFUSE_ENABLED,
+            "n8n": settings.N8N_ENABLED,
+            "mlflow": settings.MLFLOW_ENABLED,
+        },
+    )
+
+
 @router.get("/status", response_model=SystemStatusResponse)
 async def get_system_status():
     """Get overall system status."""
@@ -47,7 +75,7 @@ async def get_system_status():
 
     return SystemStatusResponse(
         name=settings.PROJECT_NAME,
-        version="1.0.0",
+        version=settings.PLATFORM_VERSION,
         runtime_mode=settings.RUNTIME_MODE,
         scheduler=SchedulerStatusResponse(
             running=discovery_scheduler.is_running,


### PR DESCRIPTION
## Summary
- Add centralized `PLATFORM_VERSION` setting to API config (eliminates hardcoded `"1.0.0"` strings)
- Add `/api/v1/system/version` endpoint returning platform version, auth mode, and service enablement status
- Add `scripts/upgrade.sh` for Docker Compose zero-downtime upgrades (pull → migrate → restart → verify)
- Add `upgrade` and `upgrade-dry-run` Makefile targets

## Files Changed
- `services/es1-platform-manager/api/app/core/config.py` — Added `PLATFORM_VERSION` setting
- `services/es1-platform-manager/api/app/main.py` — Use `settings.PLATFORM_VERSION` instead of hardcoded `"1.0.0"`
- `services/es1-platform-manager/api/app/modules/system/routes.py` — Added `VersionResponse` model and `/version` endpoint
- `scripts/upgrade.sh` — New: Docker Compose upgrade script with `--dry-run` support
- `Makefile` — Added `upgrade` and `upgrade-dry-run` targets

## Test plan
- [ ] `curl /api/v1/system/version` returns correct platform version and service status
- [ ] `scripts/upgrade.sh --dry-run` shows planned actions without changes
- [ ] `make upgrade` pulls images, runs migrations, restarts services
- [ ] Version in `/api/v1/system/status` matches `PLATFORM_VERSION` setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)