### PR TITLE
Phase 9: Feature Flags & Modular Deployment (v2.0.0)

### DIFF
--- a/docker-compose.agents.yml
+++ b/docker-compose.agents.yml
@@ -13,6 +13,7 @@ services:
   # CrewAI Service - Role-based Agent Teams
   # ==========================================================================
   crewai:
+    profiles: ["agents", "full"]
     build:
       context: ./services/agents/crewai
       dockerfile: Dockerfile
@@ -42,6 +43,7 @@ services:
   # AutoGen Service - Multi-Agent Conversations
   # ==========================================================================
   autogen:
+    profiles: ["agents", "full"]
     build:
       context: ./services/agents/autogen
       dockerfile: Dockerfile
@@ -72,6 +74,7 @@ services:
   # Routes requests to CrewAI, AutoGen, Langflow, n8n
   # ==========================================================================
   agent-router:
+    profiles: ["agents", "full"]
     build:
       context: ./services/agents/router
       dockerfile: Dockerfile

--- a/docker-compose.autogen-studio.yml
+++ b/docker-compose.autogen-studio.yml
@@ -11,6 +11,7 @@
 
 services:
   autogen-studio:
+    profiles: ["agents", "full"]
     build:
       context: ./services/agents/autogen-studio
       dockerfile: Dockerfile

--- a/docker-compose.crewai-studio.yml
+++ b/docker-compose.crewai-studio.yml
@@ -10,6 +10,7 @@
 
 services:
   crewai-studio:
+    profiles: ["agents", "full"]
     build:
       context: ./services/agents/crewai-studio
       dockerfile: Dockerfile

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -15,6 +15,7 @@
 
 services:
   prometheus:
+    profiles: ["monitoring", "full"]
     image: prom/prometheus:v2.51.0
     container_name: ${CONTAINER_PREFIX:-es1}-prometheus
     ports:
@@ -34,6 +35,7 @@ services:
       - es1-network
 
   grafana:
+    profiles: ["monitoring", "full"]
     image: grafana/grafana:10.4.0
     container_name: ${CONTAINER_PREFIX:-es1}-grafana
     ports:
@@ -60,6 +62,7 @@ services:
 
   # Container metrics exporter
   cadvisor:
+    profiles: ["monitoring", "full"]
     image: gcr.io/cadvisor/cadvisor:v0.49.1
     container_name: ${CONTAINER_PREFIX:-es1}-cadvisor
     ports:
@@ -84,6 +87,7 @@ services:
 
   # Host metrics exporter
   node-exporter:
+    profiles: ["monitoring", "full"]
     image: prom/node-exporter:v1.7.0
     container_name: ${CONTAINER_PREFIX:-es1}-node-exporter
     ports:
@@ -103,6 +107,7 @@ services:
 
   # PostgreSQL metrics exporter
   postgres-exporter:
+    profiles: ["monitoring", "full"]
     image: prometheuscommunity/postgres-exporter:v0.15.0
     container_name: ${CONTAINER_PREFIX:-es1}-postgres-exporter
     ports:
@@ -118,6 +123,7 @@ services:
 
   # Redis metrics exporter
   redis-exporter:
+    profiles: ["monitoring", "full"]
     image: oliver006/redis_exporter:v1.58.0
     container_name: ${CONTAINER_PREFIX:-es1}-redis-exporter
     ports:

--- a/docker-compose.n8n.yml
+++ b/docker-compose.n8n.yml
@@ -13,6 +13,7 @@
 
 services:
   n8n:
+    profiles: ["n8n", "full"]
     image: n8nio/n8n:latest
     container_name: ${CONTAINER_PREFIX:-es1}-n8n
     ports:

--- a/services/es1-platform-manager/api/app/core/config.py
+++ b/services/es1-platform-manager/api/app/core/config.py
@@ -146,6 +146,7 @@ class Settings(BaseSettings):
 
     OLLAMA_URL: str = "http://ollama:11434"
     OLLAMA_EMBEDDING_MODEL: str = "nomic-embed-text"
+    OLLAMA_ENABLED: bool = True
 
     # ==========================================================================
     # MLflow (experiment tracking and model registry)
@@ -161,6 +162,13 @@ class Settings(BaseSettings):
     CREWAI_URL: str = "http://crewai:8100"
     AUTOGEN_URL: str = "http://autogen:8101"
     AGENT_ROUTER_URL: str = "http://agent-router:8102"
+    AGENT_ROUTER_ENABLED: bool = True
+
+    # ==========================================================================
+    # Monitoring
+    # ==========================================================================
+
+    MONITORING_ENABLED: bool = True
 
     @property
     def auth_enabled(self) -> bool:

--- a/services/es1-platform-manager/ui/docker-entrypoint.sh
+++ b/services/es1-platform-manager/ui/docker-entrypoint.sh
@@ -39,6 +39,10 @@
 #   ENABLE_CREWAI_STUDIO  - Enable CrewAI Studio link (default: true)
 #   ENABLE_LANGFUSE       - Enable Langfuse integration (default: true)
 #   ENABLE_MLFLOW         - Enable MLflow integration (default: true)
+#   ENABLE_OLLAMA         - Enable Ollama integration (default: true)
+#   ENABLE_OPEN_WEBUI     - Enable Open WebUI link (default: true)
+#   ENABLE_MONITORING     - Enable monitoring dashboards (default: true)
+#   ENABLE_AGENT_ROUTER   - Enable agent services (default: true)
 
 set -e
 
@@ -83,6 +87,10 @@ ENABLE_CREWAI_STUDIO="${ENABLE_CREWAI_STUDIO:-true}"
 ENABLE_AUTOGEN_STUDIO="${ENABLE_AUTOGEN_STUDIO:-true}"
 ENABLE_LANGFUSE="${ENABLE_LANGFUSE:-true}"
 ENABLE_MLFLOW="${ENABLE_MLFLOW:-true}"
+ENABLE_OLLAMA="${ENABLE_OLLAMA:-true}"
+ENABLE_OPEN_WEBUI="${ENABLE_OPEN_WEBUI:-true}"
+ENABLE_MONITORING="${ENABLE_MONITORING:-true}"
+ENABLE_AGENT_ROUTER="${ENABLE_AGENT_ROUTER:-true}"
 
 # =============================================================================
 # Default values for authentication
@@ -162,6 +170,10 @@ window.__PLATFORM_CONFIG__ = {
     enableAutogenStudio: ${ENABLE_AUTOGEN_STUDIO},
     enableLangfuse: ${ENABLE_LANGFUSE},
     enableMlflow: ${ENABLE_MLFLOW},
+    enableOllama: ${ENABLE_OLLAMA},
+    enableOpenWebUI: ${ENABLE_OPEN_WEBUI},
+    enableMonitoring: ${ENABLE_MONITORING},
+    enableAgentRouter: ${ENABLE_AGENT_ROUTER},
   },
 
   branding: {

--- a/services/es1-platform-manager/ui/src/config/defaults.ts
+++ b/services/es1-platform-manager/ui/src/config/defaults.ts
@@ -46,5 +46,9 @@ export const defaultConfig: RuntimeConfig = {
     enableAutogenStudio: true,
     enableLangfuse: true,
     enableMlflow: true,
+    enableOllama: true,
+    enableOpenWebUI: true,
+    enableMonitoring: true,
+    enableAgentRouter: true,
   },
 };

--- a/services/es1-platform-manager/ui/src/config/types.ts
+++ b/services/es1-platform-manager/ui/src/config/types.ts
@@ -64,6 +64,14 @@ export interface RuntimeConfig {
     enableLangfuse: boolean;
     /** Enable MLflow integration in Models module */
     enableMlflow: boolean;
+    /** Enable Ollama/Open WebUI integration */
+    enableOllama: boolean;
+    /** Enable Open WebUI chat interface link */
+    enableOpenWebUI: boolean;
+    /** Enable monitoring dashboards (Grafana/Prometheus) */
+    enableMonitoring: boolean;
+    /** Enable Agent Router and agent services */
+    enableAgentRouter: boolean;
   };
 
   /**


### PR DESCRIPTION
## Summary
- Extend UI feature flags with `enableOllama`, `enableOpenWebUI`, `enableMonitoring`, `enableAgentRouter`
- Extend API config with `OLLAMA_ENABLED`, `AGENT_ROUTER_ENABLED`, `MONITORING_ENABLED` settings
- Add Docker Compose profiles to all optional services: `n8n`, `monitoring`, `agents`, `full`
- Enable selective deployment: `docker compose --profile monitoring --profile agents up -d`

## Files Changed
- `services/es1-platform-manager/ui/src/config/types.ts` — 4 new feature flag fields
- `services/es1-platform-manager/ui/src/config/defaults.ts` — Defaults for new flags (all `true`)
- `services/es1-platform-manager/ui/docker-entrypoint.sh` — New env vars + config.js generation for new flags
- `services/es1-platform-manager/api/app/core/config.py` — 3 new `*_ENABLED` settings
- `docker-compose.n8n.yml` — Added `profiles: ["n8n", "full"]`
- `docker-compose.monitoring.yml` — Added `profiles: ["monitoring", "full"]` to all 6 services
- `docker-compose.agents.yml` — Added `profiles: ["agents", "full"]` to all 3 services
- `docker-compose.crewai-studio.yml` — Added `profiles: ["agents", "full"]`
- `docker-compose.autogen-studio.yml` — Added `profiles: ["agents", "full"]`

## Test plan
- [ ] `docker compose up -d` starts only core services (no optional profiles)
- [ ] `docker compose --profile full up -d` starts everything
- [ ] `docker compose --profile monitoring up -d` starts core + monitoring only
- [ ] UI reflects feature flags from env vars in config.js
- [ ] API `/system/version` shows service enablement status

🤖 Generated with [Claude Code](https://claude.com/claude-code)