### PR TITLE
feat: Airflow connections CRUD + editor

### DIFF
--- a/services/es1-platform-manager/api/app/modules/airflow/client.py
+++ b/services/es1-platform-manager/api/app/modules/airflow/client.py
@@ -613,6 +613,94 @@ class AirflowClient:
             logger.error(f"Error listing connections: {e}")
             raise
 
+    async def get_connection(self, connection_id: str) -> dict[str, Any]:
+        """
+        Get details of a specific connection.
+
+        Args:
+            connection_id: The connection identifier
+
+        Returns:
+            Connection details dict
+        """
+        try:
+            client = await self._get_client()
+            response = await client.get(f"/connections/{connection_id}")
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            logger.error(f"Failed to get connection {connection_id}: {e}")
+            raise
+        except Exception as e:
+            logger.error(f"Error getting connection {connection_id}: {e}")
+            raise
+
+    async def create_connection(self, data: dict[str, Any]) -> dict[str, Any]:
+        """
+        Create a new Airflow connection.
+
+        Args:
+            data: Connection data (connection_id, conn_type, host, etc.)
+
+        Returns:
+            Created connection details
+        """
+        try:
+            client = await self._get_client()
+            response = await client.post("/connections", json=data)
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            logger.error(f"Failed to create connection: {e}")
+            raise
+        except Exception as e:
+            logger.error(f"Error creating connection: {e}")
+            raise
+
+    async def update_connection(self, connection_id: str, data: dict[str, Any]) -> dict[str, Any]:
+        """
+        Update an existing Airflow connection.
+
+        Args:
+            connection_id: The connection identifier
+            data: Fields to update
+
+        Returns:
+            Updated connection details
+        """
+        try:
+            client = await self._get_client()
+            response = await client.patch(f"/connections/{connection_id}", json=data)
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            logger.error(f"Failed to update connection {connection_id}: {e}")
+            raise
+        except Exception as e:
+            logger.error(f"Error updating connection {connection_id}: {e}")
+            raise
+
+    async def delete_connection(self, connection_id: str) -> bool:
+        """
+        Delete an Airflow connection.
+
+        Args:
+            connection_id: The connection identifier
+
+        Returns:
+            True if successful
+        """
+        try:
+            client = await self._get_client()
+            response = await client.delete(f"/connections/{connection_id}")
+            if response.status_code in (200, 204, 404):
+                return True
+            logger.warning(f"Unexpected status deleting connection {connection_id}: {response.status_code}")
+            return False
+        except Exception as e:
+            logger.error(f"Error deleting connection {connection_id}: {e}")
+            return False
+
     async def get_variables(self, limit: int = 100, offset: int = 0) -> dict[str, Any]:
         """
         List Airflow variables.

--- a/services/es1-platform-manager/api/app/modules/airflow/connection_templates.py
+++ b/services/es1-platform-manager/api/app/modules/airflow/connection_templates.py
@@ -1,0 +1,487 @@
+"""Connection type templates with field definitions for the Connection Editor."""
+
+from typing import Any
+
+# Field type constants
+TEXT = "text"
+NUMBER = "number"
+PASSWORD = "password"
+TEXTAREA = "textarea"
+SELECT = "select"
+
+# Category constants
+DATABASE = "database"
+DATA_WAREHOUSE = "data_warehouse"
+NOSQL = "nosql"
+CLOUD_STORAGE = "cloud_storage"
+API = "api"
+MESSAGING = "messaging"
+INFRASTRUCTURE = "infrastructure"
+AI_ML = "ai_ml"
+
+CATEGORIES = {
+    DATABASE: "Databases",
+    DATA_WAREHOUSE: "Data Warehouses",
+    NOSQL: "NoSQL / Search",
+    CLOUD_STORAGE: "Cloud Storage",
+    API: "APIs",
+    MESSAGING: "Messaging / Streaming",
+    INFRASTRUCTURE: "Infrastructure",
+    AI_ML: "AI / ML",
+}
+
+# Standard field builders for reuse
+_host_field = lambda placeholder="db.example.com": {
+    "name": "host", "label": "Host", "type": TEXT,
+    "required": True, "placeholder": placeholder,
+}
+_port_field = lambda default: {
+    "name": "port", "label": "Port", "type": NUMBER,
+    "required": False, "placeholder": str(default),
+}
+_schema_field = lambda placeholder="mydb", label="Database": {
+    "name": "schema", "label": label, "type": TEXT,
+    "required": False, "placeholder": placeholder,
+}
+_login_field = lambda placeholder="user": {
+    "name": "login", "label": "Username", "type": TEXT,
+    "required": False, "placeholder": placeholder,
+}
+_password_field = {
+    "name": "password", "label": "Password", "type": PASSWORD, "required": False,
+}
+_extra_field = {
+    "name": "extra", "label": "Extra (JSON)", "type": TEXTAREA,
+    "required": False, "placeholder": '{"key": "value"}',
+}
+
+
+CONNECTION_TEMPLATES: list[dict[str, Any]] = [
+    # =========================================================================
+    # Databases
+    # =========================================================================
+    {
+        "conn_type": "postgres",
+        "display_name": "PostgreSQL",
+        "description": "Connect to a PostgreSQL database",
+        "category": DATABASE,
+        "default_port": 5432,
+        "fields": [
+            _host_field(),
+            _port_field(5432),
+            _schema_field("mydb"),
+            _login_field("postgres"),
+            _password_field,
+        ],
+        "extra_schema": {"sslmode": "prefer"},
+    },
+    {
+        "conn_type": "mysql",
+        "display_name": "MySQL",
+        "description": "Connect to a MySQL database",
+        "category": DATABASE,
+        "default_port": 3306,
+        "fields": [
+            _host_field(),
+            _port_field(3306),
+            _schema_field("mydb"),
+            _login_field("root"),
+            _password_field,
+        ],
+        "extra_schema": {"charset": "utf8mb4"},
+    },
+    {
+        "conn_type": "mssql",
+        "display_name": "Microsoft SQL Server",
+        "description": "Connect to a Microsoft SQL Server database",
+        "category": DATABASE,
+        "default_port": 1433,
+        "fields": [
+            _host_field(),
+            _port_field(1433),
+            _schema_field("master"),
+            _login_field("sa"),
+            _password_field,
+        ],
+        "extra_schema": {},
+    },
+    {
+        "conn_type": "snowflake",
+        "display_name": "Snowflake",
+        "description": "Connect to Snowflake data warehouse",
+        "category": DATABASE,
+        "default_port": None,
+        "fields": [
+            {"name": "host", "label": "Account URL", "type": TEXT, "required": True, "placeholder": "account.snowflakecomputing.com"},
+            _schema_field("my_database"),
+            _login_field("snowflake_user"),
+            _password_field,
+            {"name": "extra", "label": "Extra (JSON)", "type": TEXTAREA, "required": False, "placeholder": '{"warehouse": "COMPUTE_WH", "role": "SYSADMIN", "schema": "PUBLIC"}'},
+        ],
+        "extra_schema": {"warehouse": "COMPUTE_WH", "role": "SYSADMIN", "schema": "PUBLIC"},
+    },
+    {
+        "conn_type": "google_cloud_platform",
+        "display_name": "BigQuery / GCP",
+        "description": "Connect to Google Cloud Platform (BigQuery, GCS, etc.)",
+        "category": DATABASE,
+        "default_port": None,
+        "fields": [
+            {"name": "extra", "label": "Keyfile JSON or Extra", "type": TEXTAREA, "required": True, "placeholder": '{"extra__google_cloud_platform__project": "my-project", "extra__google_cloud_platform__key_path": "/path/to/key.json"}'},
+        ],
+        "extra_schema": {"extra__google_cloud_platform__project": "", "extra__google_cloud_platform__num_retries": 5},
+    },
+    {
+        "conn_type": "redshift",
+        "display_name": "Amazon Redshift",
+        "description": "Connect to Amazon Redshift data warehouse",
+        "category": DATABASE,
+        "default_port": 5439,
+        "fields": [
+            _host_field("cluster.region.redshift.amazonaws.com"),
+            _port_field(5439),
+            _schema_field("dev"),
+            _login_field("awsuser"),
+            _password_field,
+        ],
+        "extra_schema": {},
+    },
+    {
+        "conn_type": "oracle",
+        "display_name": "Oracle",
+        "description": "Connect to an Oracle database",
+        "category": DATABASE,
+        "default_port": 1521,
+        "fields": [
+            _host_field(),
+            _port_field(1521),
+            _schema_field("ORCL", label="Service Name"),
+            _login_field("system"),
+            _password_field,
+        ],
+        "extra_schema": {},
+    },
+    # =========================================================================
+    # Data Warehouses
+    # =========================================================================
+    {
+        "conn_type": "databricks",
+        "display_name": "Databricks",
+        "description": "Connect to Databricks workspace",
+        "category": DATA_WAREHOUSE,
+        "default_port": 443,
+        "fields": [
+            {"name": "host", "label": "Workspace URL", "type": TEXT, "required": True, "placeholder": "adb-123456.azuredatabricks.net"},
+            _port_field(443),
+            {"name": "password", "label": "Access Token", "type": PASSWORD, "required": True},
+            {"name": "extra", "label": "Extra (JSON)", "type": TEXTAREA, "required": False, "placeholder": '{"http_path": "/sql/1.0/warehouses/abc123"}'},
+        ],
+        "extra_schema": {"http_path": ""},
+    },
+    {
+        "conn_type": "spark",
+        "display_name": "Apache Spark",
+        "description": "Connect to Apache Spark via Thrift server",
+        "category": DATA_WAREHOUSE,
+        "default_port": 10000,
+        "fields": [
+            _host_field("spark-master"),
+            _port_field(10000),
+            _login_field("hive"),
+            _password_field,
+        ],
+        "extra_schema": {},
+    },
+    {
+        "conn_type": "trino",
+        "display_name": "Trino / Presto",
+        "description": "Connect to Trino or Presto query engine",
+        "category": DATA_WAREHOUSE,
+        "default_port": 8080,
+        "fields": [
+            _host_field("trino-coordinator"),
+            _port_field(8080),
+            _schema_field("hive", label="Catalog"),
+            _login_field("trino"),
+            _password_field,
+        ],
+        "extra_schema": {},
+    },
+    # =========================================================================
+    # NoSQL / Search
+    # =========================================================================
+    {
+        "conn_type": "mongo",
+        "display_name": "MongoDB",
+        "description": "Connect to a MongoDB database",
+        "category": NOSQL,
+        "default_port": 27017,
+        "fields": [
+            _host_field("mongo-host"),
+            _port_field(27017),
+            _schema_field("mydb"),
+            _login_field("mongo"),
+            _password_field,
+        ],
+        "extra_schema": {},
+    },
+    {
+        "conn_type": "elasticsearch",
+        "display_name": "Elasticsearch",
+        "description": "Connect to an Elasticsearch cluster",
+        "category": NOSQL,
+        "default_port": 9200,
+        "fields": [
+            _host_field("elasticsearch"),
+            _port_field(9200),
+            _login_field("elastic"),
+            _password_field,
+        ],
+        "extra_schema": {},
+    },
+    {
+        "conn_type": "cassandra",
+        "display_name": "Apache Cassandra",
+        "description": "Connect to an Apache Cassandra cluster",
+        "category": NOSQL,
+        "default_port": 9042,
+        "fields": [
+            _host_field("cassandra-host"),
+            _port_field(9042),
+            _schema_field("my_keyspace", label="Keyspace"),
+            _login_field("cassandra"),
+            _password_field,
+        ],
+        "extra_schema": {},
+    },
+    # =========================================================================
+    # Cloud Storage
+    # =========================================================================
+    {
+        "conn_type": "aws",
+        "display_name": "AWS S3",
+        "description": "Connect to Amazon S3 and AWS services",
+        "category": CLOUD_STORAGE,
+        "default_port": None,
+        "fields": [
+            {"name": "login", "label": "AWS Access Key ID", "type": TEXT, "required": False, "placeholder": "AKIAIOSFODNN7EXAMPLE"},
+            {"name": "password", "label": "AWS Secret Access Key", "type": PASSWORD, "required": False},
+            {"name": "extra", "label": "Extra (JSON)", "type": TEXTAREA, "required": False, "placeholder": '{"region_name": "us-east-1"}'},
+        ],
+        "extra_schema": {"region_name": "us-east-1"},
+    },
+    {
+        "conn_type": "google_cloud_platform",
+        "display_name": "Google Cloud Storage",
+        "description": "Connect to Google Cloud Storage",
+        "category": CLOUD_STORAGE,
+        "default_port": None,
+        "fields": [
+            {"name": "extra", "label": "Keyfile JSON or Extra", "type": TEXTAREA, "required": True, "placeholder": '{"extra__google_cloud_platform__project": "my-project"}'},
+        ],
+        "extra_schema": {"extra__google_cloud_platform__project": ""},
+    },
+    {
+        "conn_type": "wasb",
+        "display_name": "Azure Blob Storage",
+        "description": "Connect to Azure Blob Storage",
+        "category": CLOUD_STORAGE,
+        "default_port": None,
+        "fields": [
+            {"name": "login", "label": "Storage Account Name", "type": TEXT, "required": True, "placeholder": "mystorageaccount"},
+            {"name": "password", "label": "Storage Account Key", "type": PASSWORD, "required": True},
+        ],
+        "extra_schema": {},
+    },
+    # =========================================================================
+    # APIs
+    # =========================================================================
+    {
+        "conn_type": "http",
+        "display_name": "HTTP / REST API",
+        "description": "Connect to an HTTP or REST API endpoint",
+        "category": API,
+        "default_port": 443,
+        "fields": [
+            {"name": "host", "label": "Base URL", "type": TEXT, "required": True, "placeholder": "https://api.example.com"},
+            _port_field(443),
+            _login_field(""),
+            _password_field,
+            {"name": "extra", "label": "Headers (JSON)", "type": TEXTAREA, "required": False, "placeholder": '{"Authorization": "Bearer token"}'},
+        ],
+        "extra_schema": {},
+    },
+    {
+        "conn_type": "generic",
+        "display_name": "Generic",
+        "description": "Generic connection for custom integrations",
+        "category": API,
+        "default_port": None,
+        "fields": [
+            _host_field(""),
+            _port_field(0),
+            _schema_field("", label="Schema"),
+            _login_field(""),
+            _password_field,
+            _extra_field,
+        ],
+        "extra_schema": {},
+    },
+    # =========================================================================
+    # Messaging / Streaming
+    # =========================================================================
+    {
+        "conn_type": "slack",
+        "display_name": "Slack",
+        "description": "Connect to Slack workspace",
+        "category": MESSAGING,
+        "default_port": None,
+        "fields": [
+            {"name": "password", "label": "Bot Token", "type": PASSWORD, "required": True, "placeholder": "xoxb-..."},
+        ],
+        "extra_schema": {},
+    },
+    {
+        "conn_type": "smtp",
+        "display_name": "Email / SMTP",
+        "description": "Connect to an SMTP server for sending emails",
+        "category": MESSAGING,
+        "default_port": 587,
+        "fields": [
+            _host_field("smtp.gmail.com"),
+            _port_field(587),
+            _login_field("user@example.com"),
+            _password_field,
+        ],
+        "extra_schema": {},
+    },
+    {
+        "conn_type": "kafka",
+        "display_name": "Apache Kafka",
+        "description": "Connect to an Apache Kafka cluster",
+        "category": MESSAGING,
+        "default_port": 9092,
+        "fields": [
+            _host_field("kafka-broker"),
+            _port_field(9092),
+            {"name": "extra", "label": "Extra (JSON)", "type": TEXTAREA, "required": False, "placeholder": '{"bootstrap.servers": "broker1:9092,broker2:9092"}'},
+        ],
+        "extra_schema": {"bootstrap.servers": ""},
+    },
+    # =========================================================================
+    # Infrastructure
+    # =========================================================================
+    {
+        "conn_type": "ssh",
+        "display_name": "SSH",
+        "description": "Connect to a remote server via SSH",
+        "category": INFRASTRUCTURE,
+        "default_port": 22,
+        "fields": [
+            _host_field("server.example.com"),
+            _port_field(22),
+            _login_field("ubuntu"),
+            _password_field,
+            {"name": "extra", "label": "Extra (JSON)", "type": TEXTAREA, "required": False, "placeholder": '{"key_file": "/path/to/key.pem"}'},
+        ],
+        "extra_schema": {},
+    },
+    {
+        "conn_type": "ftp",
+        "display_name": "FTP / SFTP",
+        "description": "Connect to an FTP or SFTP server",
+        "category": INFRASTRUCTURE,
+        "default_port": 21,
+        "fields": [
+            _host_field("ftp.example.com"),
+            _port_field(21),
+            _login_field("ftpuser"),
+            _password_field,
+        ],
+        "extra_schema": {},
+    },
+    # =========================================================================
+    # AI / ML
+    # =========================================================================
+    {
+        "conn_type": "openai",
+        "display_name": "OpenAI",
+        "description": "Connect to OpenAI API",
+        "category": AI_ML,
+        "default_port": None,
+        "fields": [
+            {"name": "password", "label": "API Key", "type": PASSWORD, "required": True, "placeholder": "sk-..."},
+            {"name": "extra", "label": "Extra (JSON)", "type": TEXTAREA, "required": False, "placeholder": '{"organization": "org-..."}'},
+        ],
+        "extra_schema": {},
+    },
+    {
+        "conn_type": "pinecone",
+        "display_name": "Pinecone",
+        "description": "Connect to Pinecone vector database",
+        "category": AI_ML,
+        "default_port": None,
+        "fields": [
+            {"name": "host", "label": "Environment", "type": TEXT, "required": True, "placeholder": "us-east1-gcp"},
+            {"name": "password", "label": "API Key", "type": PASSWORD, "required": True},
+        ],
+        "extra_schema": {},
+    },
+    {
+        "conn_type": "weaviate",
+        "display_name": "Weaviate",
+        "description": "Connect to Weaviate vector database",
+        "category": AI_ML,
+        "default_port": 8080,
+        "fields": [
+            _host_field("weaviate.example.com"),
+            _port_field(8080),
+            {"name": "password", "label": "API Key", "type": PASSWORD, "required": False},
+        ],
+        "extra_schema": {},
+    },
+    {
+        "conn_type": "chroma",
+        "display_name": "ChromaDB",
+        "description": "Connect to ChromaDB vector database",
+        "category": AI_ML,
+        "default_port": 8000,
+        "fields": [
+            _host_field("localhost"),
+            _port_field(8000),
+        ],
+        "extra_schema": {},
+    },
+    {
+        "conn_type": "huggingface",
+        "display_name": "Hugging Face",
+        "description": "Connect to Hugging Face API",
+        "category": AI_ML,
+        "default_port": None,
+        "fields": [
+            {"name": "password", "label": "API Token", "type": PASSWORD, "required": True, "placeholder": "hf_..."},
+        ],
+        "extra_schema": {},
+    },
+]
+
+
+def get_connection_templates() -> list[dict[str, Any]]:
+    """Get all connection templates."""
+    return CONNECTION_TEMPLATES
+
+
+def get_connection_template(conn_type: str) -> dict[str, Any] | None:
+    """Get a specific connection template by conn_type.
+
+    Returns the first matching template, or None if not found.
+    """
+    for template in CONNECTION_TEMPLATES:
+        if template["conn_type"] == conn_type:
+            return template
+    return None
+
+
+def get_template_categories() -> dict[str, str]:
+    """Get the category ID to display name mapping."""
+    return CATEGORIES.copy()

--- a/services/es1-platform-manager/api/app/modules/airflow/schemas.py
+++ b/services/es1-platform-manager/api/app/modules/airflow/schemas.py
@@ -102,6 +102,75 @@ class ConnectionListResponse(BaseModel):
     total_entries: int
 
 
+class ConnectionDetailResponse(BaseModel):
+    """Schema for single connection detail response (never includes password)."""
+    connection_id: str
+    conn_type: str | None = None
+    description: str | None = None
+    host: str | None = None
+    port: int | None = None
+    schema_name: str | None = None
+    login: str | None = None
+    extra: str | None = None
+
+
+class ConnectionCreateRequest(BaseModel):
+    """Schema for creating a connection."""
+    connection_id: str
+    conn_type: str
+    description: str | None = None
+    host: str | None = None
+    port: int | None = None
+    schema_name: str | None = None
+    login: str | None = None
+    password: str | None = None
+    extra: str | None = None
+
+
+class ConnectionUpdateRequest(BaseModel):
+    """Schema for updating a connection (PATCH semantics — all fields optional)."""
+    conn_type: str | None = None
+    description: str | None = None
+    host: str | None = None
+    port: int | None = None
+    schema_name: str | None = None
+    login: str | None = None
+    password: str | None = None
+    extra: str | None = None
+
+
+class ConnectionDeleteResponse(BaseModel):
+    """Schema for connection delete response."""
+    success: bool
+    message: str
+
+
+class ConnectionTemplateField(BaseModel):
+    """Schema for a template field definition."""
+    name: str
+    label: str
+    type: str
+    required: bool = False
+    placeholder: str | None = None
+
+
+class ConnectionTemplateResponse(BaseModel):
+    """Schema for a single connection template."""
+    conn_type: str
+    display_name: str
+    description: str
+    category: str
+    default_port: int | None = None
+    fields: list[ConnectionTemplateField]
+    extra_schema: dict[str, Any] = {}
+
+
+class ConnectionTemplateListResponse(BaseModel):
+    """Schema for connection template list response."""
+    templates: list[ConnectionTemplateResponse]
+    categories: dict[str, str]
+
+
 class AirflowHealthResponse(BaseModel):
     """Schema for Airflow health response."""
     status: str

--- a/services/es1-platform-manager/ui/src/modules/workflows/WorkflowsModule.tsx
+++ b/services/es1-platform-manager/ui/src/modules/workflows/WorkflowsModule.tsx
@@ -3,6 +3,7 @@ import { DagsView } from './views/DagsView'
 import { DagRunsView } from './views/DagRunsView'
 import { ConnectionsView } from './views/ConnectionsView'
 import { DagEditorView } from './views/DagEditorView'
+import { ConnectionEditorView } from './views/ConnectionEditorView'
 
 export function WorkflowsModule() {
   return (
@@ -61,6 +62,18 @@ export function WorkflowsModule() {
         >
           Connections
         </NavLink>
+        <NavLink
+          to="/workflows/connection-editor"
+          className={({ isActive }) =>
+            `pb-2 px-1 text-sm font-medium border-b-2 -mb-px transition-colors ${
+              isActive
+                ? 'border-primary text-primary'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            }`
+          }
+        >
+          Connection Editor
+        </NavLink>
       </nav>
 
       <Routes>
@@ -68,6 +81,7 @@ export function WorkflowsModule() {
         <Route path="/runs" element={<DagRunsView />} />
         <Route path="/editor" element={<DagEditorView />} />
         <Route path="/connections" element={<ConnectionsView />} />
+        <Route path="/connection-editor" element={<ConnectionEditorView />} />
       </Routes>
     </div>
   )

--- a/services/es1-platform-manager/ui/src/modules/workflows/views/ConnectionEditorView.tsx
+++ b/services/es1-platform-manager/ui/src/modules/workflows/views/ConnectionEditorView.tsx
@@ -1,0 +1,660 @@
+import { useState, useEffect } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useSearchParams } from 'react-router-dom'
+import {
+  Plus,
+  Save,
+  Trash2,
+  RefreshCw,
+  Cable,
+  Eye,
+  EyeOff,
+} from 'lucide-react'
+import { Button, Card, Badge } from '@/design-system/components'
+import { useToast } from '@/shared/contexts/ToastContext'
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+interface Connection {
+  connection_id: string
+  conn_type: string | null
+  description: string | null
+  host: string | null
+  port: number | null
+  schema_name: string | null
+}
+
+interface ConnectionDetail {
+  connection_id: string
+  conn_type: string | null
+  description: string | null
+  host: string | null
+  port: number | null
+  schema_name: string | null
+  login: string | null
+  extra: string | null
+}
+
+interface TemplateField {
+  name: string
+  label: string
+  type: string
+  required: boolean
+  placeholder?: string
+}
+
+interface ConnectionTemplate {
+  conn_type: string
+  display_name: string
+  description: string
+  category: string
+  default_port: number | null
+  fields: TemplateField[]
+  extra_schema: Record<string, unknown>
+}
+
+interface TemplatesResponse {
+  templates: ConnectionTemplate[]
+  categories: Record<string, string>
+}
+
+// ── Form state ─────────────────────────────────────────────────────────
+
+interface FormState {
+  connection_id: string
+  conn_type: string
+  description: string
+  host: string
+  port: string
+  schema_name: string
+  login: string
+  password: string
+  extra: string
+}
+
+const emptyForm: FormState = {
+  connection_id: '',
+  conn_type: '',
+  description: '',
+  host: '',
+  port: '',
+  schema_name: '',
+  login: '',
+  password: '',
+  extra: '',
+}
+
+// Generic fallback fields when no template matches
+const GENERIC_FIELDS: TemplateField[] = [
+  { name: 'host', label: 'Host', type: 'text', required: false, placeholder: 'hostname' },
+  { name: 'port', label: 'Port', type: 'number', required: false, placeholder: '0' },
+  { name: 'schema', label: 'Schema', type: 'text', required: false },
+  { name: 'login', label: 'Username', type: 'text', required: false },
+  { name: 'password', label: 'Password', type: 'password', required: false },
+  { name: 'extra', label: 'Extra (JSON)', type: 'textarea', required: false, placeholder: '{"key": "value"}' },
+]
+
+// ── Component ──────────────────────────────────────────────────────────
+
+export function ConnectionEditorView() {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [selectedConnection, setSelectedConnection] = useState<string | null>(searchParams.get('connection'))
+  const [form, setForm] = useState<FormState>(emptyForm)
+  const [originalForm, setOriginalForm] = useState<FormState>(emptyForm)
+  const [isNew, setIsNew] = useState(false)
+  const [newDialogOpen, setNewDialogOpen] = useState(false)
+  const [newConnId, setNewConnId] = useState('')
+  const [newConnType, setNewConnType] = useState('')
+  const [showPassword, setShowPassword] = useState(false)
+  const [changePassword, setChangePassword] = useState(false)
+  const queryClient = useQueryClient()
+  const { addToast } = useToast()
+
+  const hasUnsavedChanges = JSON.stringify(form) !== JSON.stringify(originalForm)
+
+  // URL sync
+  useEffect(() => {
+    const param = searchParams.get('connection')
+    if (param && param !== selectedConnection) {
+      setSelectedConnection(param)
+    }
+  }, [searchParams])
+
+  useEffect(() => {
+    if (selectedConnection) {
+      setSearchParams({ connection: selectedConnection }, { replace: true })
+    } else {
+      setSearchParams({}, { replace: true })
+    }
+  }, [selectedConnection])
+
+  // ── Queries ────────────────────────────────────────────────────────
+
+  const { data: connectionsData, isLoading: connectionsLoading, refetch: refetchConnections } = useQuery<{
+    connections: Connection[]
+    total_entries: number
+  }>({
+    queryKey: ['airflow', 'connections'],
+    queryFn: async () => {
+      const res = await fetch('/api/v1/airflow/connections')
+      if (!res.ok) throw new Error('Failed to fetch connections')
+      return res.json()
+    },
+  })
+
+  const { data: templatesData } = useQuery<TemplatesResponse>({
+    queryKey: ['connection-templates'],
+    queryFn: async () => {
+      const res = await fetch('/api/v1/airflow/connection-templates')
+      if (!res.ok) throw new Error('Failed to fetch templates')
+      return res.json()
+    },
+  })
+
+  const { data: connectionDetail, isLoading: detailLoading } = useQuery<ConnectionDetail>({
+    queryKey: ['airflow', 'connection', selectedConnection],
+    queryFn: async () => {
+      const res = await fetch(`/api/v1/airflow/connections/${selectedConnection}`)
+      if (!res.ok) throw new Error('Failed to fetch connection')
+      return res.json()
+    },
+    enabled: !!selectedConnection && !isNew,
+  })
+
+  // Load connection detail into form
+  useEffect(() => {
+    if (connectionDetail && !isNew) {
+      const loaded: FormState = {
+        connection_id: connectionDetail.connection_id,
+        conn_type: connectionDetail.conn_type || '',
+        description: connectionDetail.description || '',
+        host: connectionDetail.host || '',
+        port: connectionDetail.port != null ? String(connectionDetail.port) : '',
+        schema_name: connectionDetail.schema_name || '',
+        login: connectionDetail.login || '',
+        password: '', // never displayed
+        extra: connectionDetail.extra || '',
+      }
+      setForm(loaded)
+      setOriginalForm(loaded)
+      setChangePassword(false)
+      setShowPassword(false)
+    }
+  }, [connectionDetail, isNew])
+
+  // ── Mutations ──────────────────────────────────────────────────────
+
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      const payload: Record<string, unknown> = {
+        conn_type: form.conn_type,
+      }
+      if (form.description) payload.description = form.description
+      if (form.host) payload.host = form.host
+      if (form.port) payload.port = parseInt(form.port, 10)
+      if (form.schema_name) payload.schema_name = form.schema_name
+      if (form.login) payload.login = form.login
+      if (form.extra) payload.extra = form.extra
+
+      if (isNew) {
+        payload.connection_id = form.connection_id
+        if (form.password) payload.password = form.password
+        const res = await fetch('/api/v1/airflow/connections', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        })
+        if (!res.ok) {
+          const err = await res.json()
+          throw new Error(err.detail || 'Failed to create connection')
+        }
+        return res.json()
+      } else {
+        // PATCH — only send password if user chose to change it
+        if (changePassword && form.password) {
+          payload.password = form.password
+        }
+        const res = await fetch(`/api/v1/airflow/connections/${selectedConnection}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        })
+        if (!res.ok) {
+          const err = await res.json()
+          throw new Error(err.detail || 'Failed to update connection')
+        }
+        return res.json()
+      }
+    },
+    onSuccess: (data) => {
+      const connId = data.connection_id || form.connection_id
+      setIsNew(false)
+      setSelectedConnection(connId)
+      setChangePassword(false)
+      setShowPassword(false)
+      // Reset the password field so it shows "unchanged" state
+      const updated: FormState = {
+        ...form,
+        connection_id: connId,
+        password: '',
+      }
+      setForm(updated)
+      setOriginalForm(updated)
+      queryClient.invalidateQueries({ queryKey: ['airflow', 'connections'] })
+      queryClient.invalidateQueries({ queryKey: ['airflow', 'connection', connId] })
+      queryClient.invalidateQueries({ queryKey: ['resources'] })
+      addToast({ type: 'success', title: 'Connection saved', description: `${connId} saved successfully` })
+    },
+    onError: (err: Error) => {
+      addToast({ type: 'error', title: 'Save failed', description: err.message })
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: async (connectionId: string) => {
+      const res = await fetch(`/api/v1/airflow/connections/${connectionId}`, { method: 'DELETE' })
+      if (!res.ok) {
+        const err = await res.json()
+        throw new Error(err.detail || 'Failed to delete')
+      }
+      return res.json()
+    },
+    onSuccess: () => {
+      setSelectedConnection(null)
+      setForm(emptyForm)
+      setOriginalForm(emptyForm)
+      setIsNew(false)
+      queryClient.invalidateQueries({ queryKey: ['airflow', 'connections'] })
+      queryClient.invalidateQueries({ queryKey: ['resources'] })
+      addToast({ type: 'success', title: 'Connection deleted' })
+    },
+    onError: (err: Error) => {
+      addToast({ type: 'error', title: 'Delete failed', description: err.message })
+    },
+  })
+
+  // ── New connection dialog handler ──────────────────────────────────
+
+  const handleCreateNew = () => {
+    if (!newConnId || !newConnType) return
+
+    // Find matching template for defaults
+    const template = templatesData?.templates.find(t => t.conn_type === newConnType)
+
+    const newForm: FormState = {
+      connection_id: newConnId,
+      conn_type: newConnType,
+      description: '',
+      host: '',
+      port: template?.default_port != null ? String(template.default_port) : '',
+      schema_name: '',
+      login: '',
+      password: '',
+      extra: template?.extra_schema && Object.keys(template.extra_schema).length > 0
+        ? JSON.stringify(template.extra_schema, null, 2)
+        : '',
+    }
+    setForm(newForm)
+    setOriginalForm(newForm)
+    setIsNew(true)
+    setSelectedConnection(newConnId)
+    setChangePassword(true)
+    setShowPassword(false)
+    setNewDialogOpen(false)
+    setNewConnId('')
+    setNewConnType('')
+  }
+
+  // ── Template lookup for current conn_type ──────────────────────────
+
+  const currentTemplate = templatesData?.templates.find(t => t.conn_type === form.conn_type)
+  const fields = currentTemplate?.fields || GENERIC_FIELDS
+
+  // ── Form field update helper ───────────────────────────────────────
+
+  const updateField = (name: string, value: string) => {
+    // Map template field name "schema" to our form field "schema_name"
+    const formKey = name === 'schema' ? 'schema_name' : name
+    setForm(prev => ({ ...prev, [formKey]: value }))
+  }
+
+  const getFieldValue = (name: string): string => {
+    const key = name === 'schema' ? 'schema_name' : name
+    return form[key as keyof FormState] || ''
+  }
+
+  // ── Group templates by category for new dialog ─────────────────────
+
+  const templatesByCategory: Record<string, ConnectionTemplate[]> = {}
+  if (templatesData) {
+    for (const t of templatesData.templates) {
+      if (!templatesByCategory[t.category]) {
+        templatesByCategory[t.category] = []
+      }
+      templatesByCategory[t.category].push(t)
+    }
+  }
+
+  // ── Render ─────────────────────────────────────────────────────────
+
+  return (
+    <div className="flex h-[calc(100vh-16rem)] gap-4">
+      {/* Sidebar — Connection list */}
+      <Card className="w-72 flex flex-col">
+        <div className="p-3 border-b flex items-center justify-between">
+          <h3 className="font-medium flex items-center gap-2">
+            <Cable className="h-4 w-4" />
+            Connections
+          </h3>
+          <Button variant="ghost" size="sm" onClick={() => refetchConnections()}>
+            <RefreshCw className="h-4 w-4" />
+          </Button>
+        </div>
+        <div className="p-2 border-b">
+          <Button size="sm" className="w-full" onClick={() => setNewDialogOpen(true)}>
+            <Plus className="h-4 w-4 mr-1" />
+            New Connection
+          </Button>
+        </div>
+        <div className="flex-1 overflow-auto">
+          {connectionsLoading ? (
+            <div className="p-4 text-center text-muted-foreground">Loading...</div>
+          ) : !connectionsData?.connections.length ? (
+            <div className="p-4 text-center text-muted-foreground text-sm">
+              No connections found. Create one to get started.
+            </div>
+          ) : (
+            <div className="divide-y">
+              {connectionsData.connections.map((conn) => (
+                <button
+                  key={conn.connection_id}
+                  onClick={() => {
+                    if (hasUnsavedChanges) {
+                      if (!confirm('You have unsaved changes. Discard?')) return
+                    }
+                    setIsNew(false)
+                    setSelectedConnection(conn.connection_id)
+                  }}
+                  className={`w-full p-3 text-left hover:bg-accent/50 transition-colors ${
+                    selectedConnection === conn.connection_id ? 'bg-accent' : ''
+                  }`}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium text-sm truncate">{conn.connection_id}</span>
+                    {conn.conn_type && (
+                      <Badge variant="secondary" className="text-xs shrink-0">{conn.conn_type}</Badge>
+                    )}
+                  </div>
+                  {conn.host && (
+                    <div className="mt-1 text-xs text-muted-foreground truncate">
+                      {conn.host}{conn.port ? `:${conn.port}` : ''}
+                    </div>
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </Card>
+
+      {/* Main — Form editor */}
+      <Card className="flex-1 flex flex-col">
+        {selectedConnection ? (
+          <>
+            <div className="p-3 border-b flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Cable className="h-4 w-4" />
+                <span className="font-medium">{form.connection_id}</span>
+                {form.conn_type && <Badge variant="secondary">{form.conn_type}</Badge>}
+                {isNew && <Badge variant="warning">New</Badge>}
+                {hasUnsavedChanges && !isNew && <Badge variant="warning">Unsaved</Badge>}
+              </div>
+              <div className="flex gap-2">
+                {!isNew && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => {
+                      if (confirm(`Delete connection "${selectedConnection}"?`)) {
+                        deleteMutation.mutate(selectedConnection)
+                      }
+                    }}
+                    disabled={deleteMutation.isPending}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                )}
+                <Button
+                  size="sm"
+                  disabled={(!hasUnsavedChanges && !isNew) || saveMutation.isPending || !form.connection_id || !form.conn_type}
+                  onClick={() => saveMutation.mutate()}
+                >
+                  <Save className="h-4 w-4 mr-1" />
+                  {isNew ? 'Create' : 'Save'}
+                </Button>
+              </div>
+            </div>
+
+            <div className="flex-1 overflow-auto p-4 space-y-4">
+              {detailLoading && !isNew ? (
+                <div className="text-center text-muted-foreground py-8">Loading connection details...</div>
+              ) : (
+                <>
+                  {/* Connection ID (read-only for existing) */}
+                  <div>
+                    <label className="text-sm font-medium block mb-1">Connection ID</label>
+                    <input
+                      type="text"
+                      value={form.connection_id}
+                      disabled={!isNew}
+                      onChange={(e) => updateField('connection_id', e.target.value)}
+                      className="w-full px-3 py-2 border rounded bg-background disabled:bg-muted disabled:cursor-not-allowed"
+                    />
+                  </div>
+
+                  {/* Connection Type (read-only — set at creation) */}
+                  <div>
+                    <label className="text-sm font-medium block mb-1">Connection Type</label>
+                    <input
+                      type="text"
+                      value={form.conn_type}
+                      disabled
+                      className="w-full px-3 py-2 border rounded bg-muted cursor-not-allowed"
+                    />
+                  </div>
+
+                  {/* Description */}
+                  <div>
+                    <label className="text-sm font-medium block mb-1">Description</label>
+                    <input
+                      type="text"
+                      value={form.description}
+                      onChange={(e) => updateField('description', e.target.value)}
+                      placeholder="Optional description"
+                      className="w-full px-3 py-2 border rounded bg-background"
+                    />
+                  </div>
+
+                  <hr className="border-border" />
+
+                  {/* Dynamic fields from template */}
+                  {fields.map((field) => {
+                    // Password gets special handling below
+                    if (field.type === 'password') return null
+
+                    if (field.type === 'textarea') {
+                      return (
+                        <div key={field.name}>
+                          <label className="text-sm font-medium block mb-1">
+                            {field.label}
+                            {field.required && <span className="text-destructive ml-1">*</span>}
+                          </label>
+                          <textarea
+                            value={getFieldValue(field.name)}
+                            onChange={(e) => updateField(field.name, e.target.value)}
+                            placeholder={field.placeholder}
+                            rows={4}
+                            className="w-full px-3 py-2 border rounded bg-background font-mono text-sm resize-y"
+                          />
+                        </div>
+                      )
+                    }
+
+                    return (
+                      <div key={field.name}>
+                        <label className="text-sm font-medium block mb-1">
+                          {field.label}
+                          {field.required && <span className="text-destructive ml-1">*</span>}
+                        </label>
+                        <input
+                          type={field.type === 'number' ? 'number' : 'text'}
+                          value={getFieldValue(field.name)}
+                          onChange={(e) => updateField(field.name, e.target.value)}
+                          placeholder={field.placeholder}
+                          className="w-full px-3 py-2 border rounded bg-background"
+                        />
+                      </div>
+                    )
+                  })}
+
+                  {/* Password field — special handling */}
+                  {fields.some(f => f.type === 'password') && (
+                    <div>
+                      <label className="text-sm font-medium block mb-1">
+                        {fields.find(f => f.type === 'password')?.label || 'Password'}
+                      </label>
+                      {!isNew && !changePassword ? (
+                        <div className="flex items-center gap-2">
+                          <input
+                            type="password"
+                            value="••••••••"
+                            disabled
+                            className="flex-1 px-3 py-2 border rounded bg-muted cursor-not-allowed"
+                          />
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => setChangePassword(true)}
+                          >
+                            Change
+                          </Button>
+                        </div>
+                      ) : (
+                        <div className="flex items-center gap-2">
+                          <div className="relative flex-1">
+                            <input
+                              type={showPassword ? 'text' : 'password'}
+                              value={form.password}
+                              onChange={(e) => updateField('password', e.target.value)}
+                              placeholder={isNew ? 'Enter password' : 'Enter new password'}
+                              className="w-full px-3 py-2 border rounded bg-background pr-10"
+                            />
+                            <button
+                              type="button"
+                              onClick={() => setShowPassword(!showPassword)}
+                              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                            >
+                              {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                            </button>
+                          </div>
+                          {!isNew && (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => {
+                                setChangePassword(false)
+                                setForm(prev => ({ ...prev, password: '' }))
+                              }}
+                            >
+                              Cancel
+                            </Button>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  )}
+
+                  {/* Extra field if not already in template fields */}
+                  {!fields.some(f => f.name === 'extra') && (
+                    <div>
+                      <label className="text-sm font-medium block mb-1">Extra (JSON)</label>
+                      <textarea
+                        value={form.extra}
+                        onChange={(e) => updateField('extra', e.target.value)}
+                        placeholder='{"key": "value"}'
+                        rows={4}
+                        className="w-full px-3 py-2 border rounded bg-background font-mono text-sm resize-y"
+                      />
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          </>
+        ) : (
+          <div className="flex-1 flex items-center justify-center text-muted-foreground">
+            <div className="text-center">
+              <Cable className="h-12 w-12 mx-auto mb-4 opacity-50" />
+              <p>Select a connection to edit</p>
+              <p className="text-sm mt-1">or create a new one</p>
+            </div>
+          </div>
+        )}
+      </Card>
+
+      {/* New Connection Dialog */}
+      {newDialogOpen && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <Card className="w-[520px] max-h-[80vh] flex flex-col p-6">
+            <h2 className="text-lg font-semibold mb-4">New Connection</h2>
+            <div className="space-y-4">
+              <div>
+                <label className="text-sm font-medium block mb-1">Connection ID *</label>
+                <input
+                  type="text"
+                  value={newConnId}
+                  onChange={(e) => setNewConnId(e.target.value)}
+                  placeholder="my_postgres_conn"
+                  className="w-full px-3 py-2 border rounded bg-background"
+                />
+                <p className="text-xs text-muted-foreground mt-1">
+                  Unique identifier for this connection
+                </p>
+              </div>
+              <div>
+                <label className="text-sm font-medium block mb-1">Connection Type *</label>
+                <select
+                  value={newConnType}
+                  onChange={(e) => setNewConnType(e.target.value)}
+                  className="w-full px-3 py-2 border rounded bg-background"
+                >
+                  <option value="">Select a type...</option>
+                  {Object.entries(templatesByCategory).map(([category, templates]) => (
+                    <optgroup key={category} label={templatesData?.categories[category] || category}>
+                      {templates.map((t) => (
+                        <option key={`${t.conn_type}-${t.display_name}`} value={t.conn_type}>
+                          {t.display_name} — {t.description}
+                        </option>
+                      ))}
+                    </optgroup>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <div className="flex justify-end gap-2 mt-6">
+              <Button variant="outline" onClick={() => { setNewDialogOpen(false); setNewConnId(''); setNewConnType('') }}>
+                Cancel
+              </Button>
+              <Button
+                disabled={!newConnId || !newConnType}
+                onClick={handleCreateNew}
+              >
+                Continue
+              </Button>
+            </div>
+          </Card>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/services/es1-platform-manager/ui/src/modules/workflows/views/ConnectionsView.tsx
+++ b/services/es1-platform-manager/ui/src/modules/workflows/views/ConnectionsView.tsx
@@ -1,12 +1,16 @@
-import { useQuery } from '@tanstack/react-query'
-import { Card, Badge } from '../../../design-system/components'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
+import { Cable, FileCode, ExternalLink, RefreshCw, Trash2, Pencil } from 'lucide-react'
+import { Card, Button, Badge, Skeleton, SkeletonList, ErrorDisplay, EmptyState } from '../../../design-system/components'
+import { useToast } from '../../../shared/contexts/ToastContext'
+import { serviceUrl } from '@/config'
 
 interface Connection {
   connection_id: string
-  conn_type: string
+  conn_type: string | null
   host: string | null
   port: number | null
-  schema: string | null
+  schema_name: string | null
   description: string | null
 }
 
@@ -22,20 +26,72 @@ async function fetchConnections(): Promise<ConnectionsResponse> {
 }
 
 export function ConnectionsView() {
-  const { data, isLoading, error } = useQuery({
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+  const { addToast } = useToast()
+
+  const { data, isLoading, error, refetch } = useQuery({
     queryKey: ['airflow', 'connections'],
     queryFn: fetchConnections,
+    refetchInterval: 15000,
+  })
+
+  const syncMutation = useMutation({
+    mutationFn: async () => {
+      const res = await fetch('/api/v1/airflow/discover', { method: 'POST' })
+      if (!res.ok) throw new Error('Failed to sync')
+      return res.json()
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['airflow', 'connections'] })
+      queryClient.invalidateQueries({ queryKey: ['resources'] })
+      addToast({ type: 'success', message: data.message || 'Synced with Airflow' })
+    },
+    onError: (error: Error) => {
+      addToast({ type: 'error', message: error.message })
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: async (connectionId: string) => {
+      const res = await fetch(`/api/v1/airflow/connections/${connectionId}`, { method: 'DELETE' })
+      if (!res.ok) {
+        const err = await res.json()
+        throw new Error(err.detail || 'Failed to delete connection')
+      }
+      return res.json()
+    },
+    onSuccess: (_, connectionId) => {
+      queryClient.invalidateQueries({ queryKey: ['airflow', 'connections'] })
+      queryClient.invalidateQueries({ queryKey: ['resources'] })
+      addToast({ type: 'success', message: `Connection ${connectionId} deleted` })
+    },
+    onError: (error: Error) => {
+      addToast({ type: 'error', message: error.message })
+    },
   })
 
   if (isLoading) {
-    return <div className="text-muted-foreground">Loading connections...</div>
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-4 w-40" />
+        </div>
+        <SkeletonList items={4} />
+      </div>
+    )
   }
 
   if (error) {
     return (
-      <Card className="p-4 border-destructive">
-        <p className="text-destructive">Failed to load connections: {(error as Error).message}</p>
-      </Card>
+      <ErrorDisplay
+        title="Failed to load connections"
+        message="Could not fetch connections from Airflow. The service may be unavailable."
+        error={error as Error}
+        onRetry={() => refetch()}
+        suggestion="Check if Airflow is running and healthy."
+        helpLink={{ label: 'Open Airflow', url: serviceUrl('airflow') }}
+      />
     )
   }
 
@@ -43,12 +99,12 @@ export function ConnectionsView() {
 
   if (connections.length === 0) {
     return (
-      <Card className="p-8 text-center">
-        <p className="text-muted-foreground">No connections found</p>
-        <p className="text-sm text-muted-foreground mt-1">
-          Connections are configured in Airflow.
-        </p>
-      </Card>
+      <EmptyState
+        icon={Cable}
+        title="No connections found"
+        description="Create a new connection using the Connection Editor, or configure connections directly in Airflow."
+        action={{ label: 'Open Connection Editor', href: '/workflows/connection-editor' }}
+      />
     )
   }
 
@@ -58,6 +114,29 @@ export function ConnectionsView() {
         <p className="text-sm text-muted-foreground">
           {connections.length} connection{connections.length !== 1 ? 's' : ''} configured
         </p>
+        <div className="flex items-center gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => syncMutation.mutate()}
+            disabled={syncMutation.isPending}
+          >
+            <RefreshCw className={`h-4 w-4 mr-1 ${syncMutation.isPending ? 'animate-spin' : ''}`} />
+            Sync
+          </Button>
+          <Button size="sm" variant="outline" onClick={() => navigate('/workflows/connection-editor')}>
+            <FileCode className="h-4 w-4 mr-1" />
+            Connection Editor
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => window.open(serviceUrl('airflow'), '_blank')}
+          >
+            <ExternalLink className="h-4 w-4 mr-1" />
+            Airflow
+          </Button>
+        </div>
       </div>
 
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
@@ -65,24 +144,47 @@ export function ConnectionsView() {
           <Card key={conn.connection_id} className="p-4">
             <div className="space-y-2">
               <div className="flex items-center justify-between">
-                <h3 className="font-medium">{conn.connection_id}</h3>
-                <Badge variant="secondary">{conn.conn_type}</Badge>
+                <h3 className="font-medium truncate">{conn.connection_id}</h3>
+                {conn.conn_type && <Badge variant="secondary">{conn.conn_type}</Badge>}
               </div>
               {conn.description && (
-                <p className="text-sm text-muted-foreground">{conn.description}</p>
+                <p className="text-sm text-muted-foreground line-clamp-2">{conn.description}</p>
               )}
               <div className="text-xs text-muted-foreground space-y-1">
                 {conn.host && (
                   <p>
                     <span className="font-medium">Host:</span> {conn.host}
-                    {conn.port && `:${conn.port}`}
+                    {conn.port ? `:${conn.port}` : ''}
                   </p>
                 )}
-                {conn.schema && (
+                {conn.schema_name && (
                   <p>
-                    <span className="font-medium">Schema:</span> {conn.schema}
+                    <span className="font-medium">Schema:</span> {conn.schema_name}
                   </p>
                 )}
+              </div>
+              <div className="flex items-center gap-2 pt-2 border-t">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => navigate(`/workflows/connection-editor?connection=${encodeURIComponent(conn.connection_id)}`)}
+                  title="Edit connection"
+                >
+                  <Pencil className="h-4 w-4" />
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => {
+                    if (confirm(`Delete connection "${conn.connection_id}"?`)) {
+                      deleteMutation.mutate(conn.connection_id)
+                    }
+                  }}
+                  disabled={deleteMutation.isPending}
+                  title="Delete connection"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
               </div>
             </div>
           </Card>


### PR DESCRIPTION
## Summary
- Add full CRUD for Airflow connections (GET/POST/PATCH/DELETE) with gateway sync
- Add Connection Editor view with split-panel layout and template-driven forms
- Add 27 connection templates across 8 categories (databases, cloud, AI/ML, etc.)
- Rewrite Connections list view with edit/delete/sync actions and proper loading states

## Test plan
- [ ] `GET /api/v1/airflow/connection-templates` returns all templates
- [ ] `POST /api/v1/airflow/connections` creates connection in Airflow
- [ ] `PATCH /api/v1/airflow/connections/{id}` updates connection
- [ ] `DELETE /api/v1/airflow/connections/{id}` deletes + removes gateway resource
- [ ] Connections tab: edit/delete/sync buttons work
- [ ] Connection Editor: create from template, edit existing, password masking
- [ ] URL deep-linking: `?connection=conn_id` selects connection
- [ ] Gateway resources sync on create/delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)