### PR TITLE
fix(config): remove hardcoded URLs that break GKE deployment

### DIFF
--- a/services/es1-platform-manager/api/app/modules/mlflow/routes.py
+++ b/services/es1-platform-manager/api/app/modules/mlflow/routes.py
@@ -7,7 +7,7 @@ from app.core.config import settings
 
 router = APIRouter(prefix="/mlflow", tags=["MLflow"])
 
-MLFLOW_URL = getattr(settings, 'MLFLOW_URL', 'http://es1-mlflow:5000')
+MLFLOW_URL = settings.MLFLOW_URL
 
 
 async def mlflow_request(method: str, endpoint: str, **kwargs) -> dict:

--- a/services/es1-platform-manager/api/app/modules/models/routes.py
+++ b/services/es1-platform-manager/api/app/modules/models/routes.py
@@ -15,8 +15,8 @@ from app.core.database import get_db
 
 router = APIRouter(prefix="/models", tags=["Models Inventory"])
 
-OLLAMA_URL = getattr(settings, 'OLLAMA_URL', 'http://es1-ollama:11434')
-MLFLOW_URL = getattr(settings, 'MLFLOW_URL', 'http://es1-mlflow:5000')
+OLLAMA_URL = settings.OLLAMA_URL
+MLFLOW_URL = settings.MLFLOW_URL
 
 
 # =============================================================================

--- a/services/es1-platform-manager/api/app/modules/n8n/client.py
+++ b/services/es1-platform-manager/api/app/modules/n8n/client.py
@@ -81,7 +81,7 @@ class N8NClient:
                         return {
                             "status": "setup_required",
                             "message": "n8n is running but API key not configured",
-                            "setup_url": "http://localhost:5678",
+                            "setup_url": settings.N8N_URL,
                         }
                     return {"status": "healthy", "data": {"message": "n8n is running"}}
                 return {"status": "unhealthy", "error": f"HTTP {response.status_code}"}

--- a/services/es1-platform-manager/api/app/modules/observability/client.py
+++ b/services/es1-platform-manager/api/app/modules/observability/client.py
@@ -63,7 +63,7 @@ class LangfuseClient:
                     return {
                         "status": "setup_required",
                         "message": "Langfuse is running but API keys not configured. Create API keys in Langfuse UI.",
-                        "setup_url": "http://localhost:3000/project/default/settings/api-keys",
+                        "setup_url": f"{settings.LANGFUSE_URL}/project/default/settings/api-keys",
                     }
                 return {"status": "healthy", "data": response.json()}
             return {"status": "unhealthy", "error": f"HTTP {response.status_code}"}

--- a/services/es1-platform-manager/api/app/modules/ollama/routes.py
+++ b/services/es1-platform-manager/api/app/modules/ollama/routes.py
@@ -8,7 +8,7 @@ from app.core.config import settings
 
 router = APIRouter(prefix="/ollama", tags=["Ollama"])
 
-OLLAMA_URL = getattr(settings, 'OLLAMA_URL', 'http://es1-ollama:11434')
+OLLAMA_URL = settings.OLLAMA_URL
 
 
 class ModelPullRequest(BaseModel):

--- a/services/krakend/config/krakend.json
+++ b/services/krakend/config/krakend.json
@@ -1,4 +1,5 @@
 {
+  "@comment": "Docker Compose base config. Backend hosts use compose service names (es1-platform-manager-api, airflow-webserver, etc) and static URLs (admin_ui) reference localhost. For Kubernetes, the Helm chart must provide a K8s-specific overlay with correct service names, namespaced DNS (e.g. airflow-webserver.<namespace>.svc.cluster.local), and external-facing URLs.",
   "$schema": "https://www.krakend.io/schema/krakend.json",
   "version": 3,
   "name": "ES1 Platform API Gateway",

--- a/services/krakend/config/krakend.json.tmpl
+++ b/services/krakend/config/krakend.json.tmpl
@@ -98,7 +98,7 @@
                 "agents": "/api/v1/agents/*",
                 "n8n-webhooks": "/webhook/*"
               },
-              "admin_ui": "http://localhost:3001"
+              "admin_ui": "${KRAKEND_ADMIN_UI_URL}"
             },
             "strategy": "always"
           }


### PR DESCRIPTION
## Summary
- Remove `getattr(settings, ..., 'http://es1-*')` fallbacks in ollama, models, and mlflow routes — the fallbacks used wrong `es1-` prefixed hostnames and were dead code since the settings fields always exist
- Replace hardcoded `localhost` setup URLs in n8n and Langfuse health checks with `settings.N8N_URL` and `settings.LANGFUSE_URL` — these are returned to the UI and need to resolve in GKE
- Parameterize `admin_ui` in `krakend.json.tmpl` as `${KRAKEND_ADMIN_UI_URL}` for K8s deployments
- Add `@comment` to `krakend.json` documenting that backend hosts use Docker Compose service names and need a K8s overlay for Helm deployment

## Files Changed
| File | Change |
|------|--------|
| `ollama/routes.py` | `getattr(settings, 'OLLAMA_URL', ...)` → `settings.OLLAMA_URL` |
| `models/routes.py` | Same for `OLLAMA_URL` and `MLFLOW_URL` |
| `mlflow/routes.py` | Same for `MLFLOW_URL` |
| `n8n/client.py` | `"http://localhost:5678"` → `settings.N8N_URL` |
| `observability/client.py` | `"http://localhost:3000/..."` → `f"{settings.LANGFUSE_URL}/..."` |
| `krakend.json` | Added `@comment` about K8s overlay requirement |
| `krakend.json.tmpl` | `"http://localhost:3001"` → `"${KRAKEND_ADMIN_UI_URL}"` |

## Test plan
- [ ] Verify API starts without import errors
- [ ] Verify n8n health check returns configurable URL
- [ ] Verify Langfuse health check returns configurable URL
- [ ] Verify KrakenD loads with the `@comment` field (JSON comments are supported via `@comment`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)